### PR TITLE
feat: add auto update command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,4 +46,5 @@ func init() {
 	// Add subcommands
 	rootCmd.AddCommand(branchesCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(selfUpdateCmd)
 }

--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+
+	"github.com/fynelabs/selfupdate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	checkOnly bool
+)
+
+var selfUpdateCmd = &cobra.Command{
+	Use:   "self-update",
+	Short: "Update git-gone to the latest version",
+	Long: `Update git-gone to the latest version from GitHub releases
+
+This command will:
+  1. Check for the latest version available
+  2. Download the binary for your platform
+  3. Verify and apply the update
+  4. Replace the current executable`,
+	Example: `  # Update to the latest version
+  git-gone self-update
+
+  # Check for updates without applying them
+  git-gone self-update --check`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runSelfUpdate()
+	},
+}
+
+func init() {
+	selfUpdateCmd.Flags().BoolVarP(&checkOnly, "check", "c", false, "Only check for updates without applying them")
+}
+
+func runSelfUpdate() {
+	fmt.Println("🔍 Checking for updates...")
+
+	// Construct the GitHub release URL
+	// Format: https://github.com/{owner}/{repo}/releases/download/{version}/{binary}-{os}-{arch}
+	owner := "theburrowhub"
+	repo := "git-gone"
+	
+	// Get the appropriate binary name and extension for the platform
+	binaryName := "git-gone"
+	
+	// Map OS names to match release artifacts
+	osName := runtime.GOOS
+	if osName == "darwin" {
+		osName = "macos"
+	}
+	
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
+
+	// Build the URL for the latest release
+	url := fmt.Sprintf("https://github.com/%s/%s/releases/latest/download/%s-%s-%s%s",
+		owner, repo, binaryName, osName, runtime.GOARCH, ext)
+
+	fmt.Printf("📦 Platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("🔗 Update URL: %s\n", url)
+
+	if checkOnly {
+		fmt.Println("ℹ️  Check-only mode: Would fetch from:", url)
+		fmt.Println("✅ Use without --check flag to apply the update")
+		return
+	}
+
+	// Download the new binary
+	fmt.Println("⬇️  Downloading latest version...")
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Printf("❌ Failed to download update: %v\n", err)
+		fmt.Println("\nℹ️  Possible reasons:")
+		fmt.Println("  • No internet connection")
+		fmt.Println("  • Latest release not available for your platform")
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("❌ Failed to download update: HTTP %d\n", resp.StatusCode)
+		if resp.StatusCode == http.StatusNotFound {
+			fmt.Println("\nℹ️  No release found for your platform.")
+			fmt.Printf("    Platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		}
+		os.Exit(1)
+	}
+
+	// Show download progress
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("❌ Failed to read update: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✅ Downloaded %d bytes\n", len(body))
+	fmt.Println("🔄 Applying update...")
+
+	// Apply the update
+	err = selfupdate.Apply(io.NopCloser(bytes.NewReader(body)), selfupdate.Options{})
+	if err != nil {
+		if rerr := selfupdate.RollbackError(err); rerr != nil {
+			fmt.Printf("❌ Failed to rollback from bad update: %v\n", rerr)
+		}
+		fmt.Printf("❌ Update failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("✅ Successfully updated to the latest version!")
+	fmt.Println("🔄 Please restart git-gone to use the new version")
+}
+

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.24.2 // indirect
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/fynelabs/selfupdate v0.2.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/fynelabs/selfupdate v0.2.1 h1:jaU85o1tnzsyICg29YfQurQPlMV4oSHLmomFIGatsgk=
+github.com/fynelabs/selfupdate v0.2.1/go.mod h1:V2z7H295LzTph5mYBnm3EDRN+oKf7G2VU5B0pc77jdw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/koki-develop/go-fzf v0.15.0 h1:M7wqkU6YtfHa5pXe3d6aWy5T5AvoGVfp78fDvp5TdkI=
@@ -44,6 +46,7 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This pull request adds a new self-update feature to the `git-gone` CLI tool, allowing users to easily check for and apply updates directly from GitHub releases. The main changes include introducing a new `self-update` command, implementing the update logic, and adding a dependency for update functionality.

**Self-update feature:**

* Added a new `self-update` command in `cmd/selfupdate.go` that enables users to check for and apply updates to `git-gone` from GitHub releases. The command supports a `--check` flag for checking updates without applying them.
* Registered the new `self-update` command in the CLI by adding it to the command tree in `cmd/root.go`.

**Dependency management:**

* Added the `github.com/fynelabs/selfupdate` package to `go.mod` to support applying binary updates safely.