### PR TITLE
feat: introduce 'report' command for branch analysis in README and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ git-gone branches
 ### Available Commands
 
 - **`git-gone` or `git-gone branches`**: Clean up merged branches (default)
-- **`git-gone --report`**: Generate branch analysis report without deleting
+- **`git-gone report`**: Generate branch analysis report without deleting
 - **`git-gone version`**: Show version information
 - **`git-gone help`**: Show help information
 
@@ -105,33 +105,34 @@ Generate a detailed analysis report without deleting any branches:
 ### Basic Report
 
 ```bash
-git-gone --report
-git-gone -r
+git-gone report
 ```
 
 ### Output Formats
 
 ```bash
 # Text format (default)
-git-gone --report --output text
+git-gone report --output text
 
 # JSON format (for scripting/automation)
-git-gone --report --output json
+git-gone report --output json
+git-gone report -o json
 
 # CSV format (for spreadsheets)
-git-gone --report --output csv
+git-gone report --output csv
 ```
 
 ### Save to File
 
 ```bash
-git-gone --report --output json --file report.json
+git-gone report --output json --file report.json
 ```
 
 ### Include Unmerged Branches
 
 ```bash
-git-gone --report --unmerged
+git-gone report --unmerged
+git-gone report -u
 ```
 
 ### Report Categories
@@ -200,14 +201,14 @@ git-gone branches
 
 # Get help for specific command
 git-gone branches --help
+git-gone report --help
 
 # Generate analysis report
-git-gone --report
-git-gone -r
+git-gone report
 
 # Report in JSON format
-git-gone --report --output json
-git-gone -r -o json
+git-gone report --output json
+git-gone report -o json
 ```
 
 **Note**: When using as a Git plugin (`git gone`), commands work the same way:

--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -56,25 +56,6 @@ Interactive Controls:
 }
 
 func runCleanup() {
-	// Report mode: generate analysis and exit without deleting
-	if reportMode {
-		// Check if we're in a git repository
-		if err := checkGitRepository(); err != nil {
-			fmt.Println("❌ Not in a git repository")
-			os.Exit(1)
-		}
-
-		fmt.Println("🔄 Updating remote references...")
-		if err := updateRemoteRefs(); err != nil {
-			fmt.Printf("⚠️  Warning: Failed to update remote refs: %v\n", err)
-		}
-
-		fmt.Println("📊 Analyzing branches...")
-		report := analyzeBranches()
-		outputReport(report, outputFormat, outputFile)
-		return
-	}
-
 	// Validate incompatible flags
 	if selectAll && forceDelete {
 		fmt.Println("❌ Options -a (--all) and -f (--force) are incompatible")

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -106,7 +106,7 @@ func getRepositoryPath() string {
 }
 
 // analyzeBranches collects and classifies all branches in the repository
-func analyzeBranches() *AnalysisReport {
+func analyzeBranches(includeUnmerged bool) *AnalysisReport {
 	report := &AnalysisReport{
 		Repository:   getRepositoryPath(),
 		AnalysisDate: time.Now().Format("2006-01-02 15:04:05"),

--- a/cmd/report_cmd.go
+++ b/cmd/report_cmd.go
@@ -67,10 +67,7 @@ func runReport() {
 		fmt.Printf("⚠️  Warning: Failed to update remote refs: %v\n", err)
 	}
 
-	// Set the global includeUnmerged flag for analyzeBranches to use
-	includeUnmerged = reportIncludeUnmerged
-
 	fmt.Println("📊 Analyzing branches...")
-	report := analyzeBranches()
+	report := analyzeBranches(reportIncludeUnmerged)
 	outputReport(report, reportOutputFormat, reportOutputFile)
 }

--- a/cmd/report_cmd.go
+++ b/cmd/report_cmd.go
@@ -9,9 +9,8 @@ import (
 
 // Report command flags
 var (
-	reportOutputFormat    string
-	reportOutputFile      string
-	reportIncludeUnmerged bool
+	reportOutputFormat string
+	reportOutputFile   string
 )
 
 var reportCmd = &cobra.Command{
@@ -52,7 +51,7 @@ Output formats available:
 func init() {
 	reportCmd.Flags().StringVarP(&reportOutputFormat, "output", "o", "text", "Report output format (text, json, csv)")
 	reportCmd.Flags().StringVar(&reportOutputFile, "file", "", "Write report to file instead of stdout")
-	reportCmd.Flags().BoolVarP(&reportIncludeUnmerged, "unmerged", "u", false, "Include unmerged branches in the report")
+	// Note: --unmerged/-u flag is inherited from root command as a persistent flag
 }
 
 func runReport() {
@@ -68,6 +67,6 @@ func runReport() {
 	}
 
 	fmt.Println("📊 Analyzing branches...")
-	report := analyzeBranches(reportIncludeUnmerged)
+	report := analyzeBranches(includeUnmerged)
 	outputReport(report, reportOutputFormat, reportOutputFile)
 }

--- a/cmd/report_cmd.go
+++ b/cmd/report_cmd.go
@@ -74,4 +74,3 @@ func runReport() {
 	report := analyzeBranches()
 	outputReport(report, reportOutputFormat, reportOutputFile)
 }
-

--- a/cmd/report_cmd.go
+++ b/cmd/report_cmd.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Report command flags
+var (
+	reportOutputFormat    string
+	reportOutputFile      string
+	reportIncludeUnmerged bool
+)
+
+var reportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Generate branch analysis report without deleting",
+	Long: `Generate a detailed analysis report of all branches in the repository.
+
+This command analyzes your repository branches and generates a comprehensive
+report showing which branches are safe to delete, which are local-only,
+unmerged, or protected.
+
+The report includes:
+  - Safe to delete: Merged branches or branches with deleted remotes
+  - Local-only: Branches that were never pushed to remote
+  - Unmerged: Branches with unmerged changes (when -u flag is used)
+  - Protected: Default branch and currently checked out branch
+
+Output formats available:
+  - text: Human-readable formatted report (default)
+  - json: Machine-readable JSON format
+  - csv: Spreadsheet-compatible CSV format`,
+	Example: `  # Generate a text report to stdout
+  git-gone report
+
+  # Generate a JSON report
+  git-gone report --output json
+
+  # Save report to a file
+  git-gone report --file branches-report.txt
+
+  # Generate CSV report including unmerged branches
+  git-gone report -u --output csv --file report.csv`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runReport()
+	},
+}
+
+func init() {
+	reportCmd.Flags().StringVarP(&reportOutputFormat, "output", "o", "text", "Report output format (text, json, csv)")
+	reportCmd.Flags().StringVar(&reportOutputFile, "file", "", "Write report to file instead of stdout")
+	reportCmd.Flags().BoolVarP(&reportIncludeUnmerged, "unmerged", "u", false, "Include unmerged branches in the report")
+}
+
+func runReport() {
+	// Check if we're in a git repository
+	if err := checkGitRepository(); err != nil {
+		fmt.Println("❌ Not in a git repository")
+		os.Exit(1)
+	}
+
+	fmt.Println("🔄 Updating remote references...")
+	if err := updateRemoteRefs(); err != nil {
+		fmt.Printf("⚠️  Warning: Failed to update remote refs: %v\n", err)
+	}
+
+	// Set the global includeUnmerged flag for analyzeBranches to use
+	includeUnmerged = reportIncludeUnmerged
+
+	fmt.Println("📊 Analyzing branches...")
+	report := analyzeBranches()
+	outputReport(report, reportOutputFormat, reportOutputFile)
+}
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,6 @@ var (
 	forceDelete     bool
 	selectAll       bool
 	includeUnmerged bool
-	reportMode      bool
-	outputFormat    string
-	outputFile      string
 )
 
 var rootCmd = &cobra.Command{
@@ -49,12 +46,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&forceDelete, "force", "f", false, "Skip confirmation prompt and delete selected branches immediately")
 	rootCmd.PersistentFlags().BoolVarP(&selectAll, "all", "a", false, "Select all candidate branches without interactive selection (incompatible with -f)")
 	rootCmd.PersistentFlags().BoolVarP(&includeUnmerged, "unmerged", "u", false, "Include unmerged branches in the list (marked with ⚠️, always requires confirmation)")
-	rootCmd.PersistentFlags().BoolVarP(&reportMode, "report", "r", false, "Generate analysis report without deleting branches")
-	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "text", "Report output format (text, json, csv)")
-	rootCmd.PersistentFlags().StringVar(&outputFile, "file", "", "Write report to file instead of stdout")
 
 	// Add subcommands
 	rootCmd.AddCommand(branchesCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(selfUpdateCmd)
+	rootCmd.AddCommand(reportCmd)
 }


### PR DESCRIPTION
- Updated README.md to reflect the new 'git-gone report' command for generating branch analysis reports without deletion.
- Removed deprecated report mode from branches.go and added a dedicated report command in report_cmd.go.
- Adjusted root command to include the new report command, enhancing usability for branch management.